### PR TITLE
Add OKD Hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /build/
 
 RUN make
 
-FROM docker.io/galenguyer/nginx:1.21.3
+FROM docker.io/galenguyer/nginx:mainline
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /build/csh-coc.pdf /usr/share/nginx/html/csh-coc.pdf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/debian:bullseye AS builder
+
+RUN apt-get update -y && \
+    apt-get install -y texlive texlive-formats-extra make git
+
+WORKDIR /build/
+
+COPY . /build/
+
+RUN make
+
+FROM docker.io/galenguyer/nginx:1.21.3
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder /build/csh-coc.pdf /usr/share/nginx/html/csh-coc.pdf
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Source files
+TEXFILES=constitution.tex
+
+# Binaries
+PDFLATEX=pdflatex
+
+# Generated files
+PDFFILES=$(TEXFILES:.tex=.pdf)
+
+.PHONY: all clean
+
+all:
+	$(PDFLATEX) `git log -1 --date=short --format=format:'\newcommand{\RevisionInfo}{Revision %h on %ad}'` '\input{csh-coc.tex}'
+	$(PDFLATEX) `git log -1 --date=short --format=format:'\newcommand{\RevisionInfo}{Revision %h on %ad}'` '\input{csh-coc.tex}'
+
+clean:
+	$(RM) $(PDFFILES)
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri /csh-coc.pdf =404;
+        }
+    }
+}
+


### PR DESCRIPTION
Adds necessary files to build and host CoC PDF on OKD, preferably under coc.csh.rit.edu


Currently at http://code-of-conduct-public-skyz-coc.apps.okd4.csh.rit.edu